### PR TITLE
feat: 아고리 생성 API 추가

### DIFF
--- a/src/main/java/com/attica/athens/agora/controller/v1/AgoraControllerV1.java
+++ b/src/main/java/com/attica/athens/agora/controller/v1/AgoraControllerV1.java
@@ -1,0 +1,38 @@
+package com.attica.athens.agora.controller.v1;
+
+import com.attica.athens.agora.domain.Agora;
+import com.attica.athens.agora.dto.AgoraResponse;
+import com.attica.athens.agora.dto.CreateAgoraRequestDto;
+import com.attica.athens.agora.dto.CreateAgoraResponseDto;
+import com.attica.athens.agora.service.v1.AgoraServiceV1;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/agoras")
+public class AgoraControllerV1 {
+
+    private final AgoraServiceV1 agoraServiceV1;
+
+    public AgoraControllerV1(AgoraServiceV1 agoraServiceV1) {
+        this.agoraServiceV1 = agoraServiceV1;
+    }
+
+    @PostMapping
+    public ResponseEntity<AgoraResponse<CreateAgoraResponseDto>> createAgora(
+        @RequestBody CreateAgoraRequestDto requestDto
+    ) {
+        Agora agora = agoraServiceV1.create(requestDto);
+        CreateAgoraResponseDto response = new CreateAgoraResponseDto(agora.getId());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(AgoraResponse.<CreateAgoraResponseDto>builder()
+                .success(true)
+                .response(response)
+                .build());
+    }
+}

--- a/src/main/java/com/attica/athens/agora/domain/Agora.java
+++ b/src/main/java/com/attica/athens/agora/domain/Agora.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -43,4 +44,14 @@ public class Agora {
     @ManyToOne
     @JoinColumn(name = "code")
     private Category code;
+
+    @Builder
+    public Agora(String title, Integer capacity, LocalTime duration, Category code) {
+        this.title = title;
+        this.capacity = capacity;
+        this.duration = duration;
+        this.viewCount = 0;
+        this.agoraStatus = AgoraStatus.RUNNING;
+        this.code = code;
+    }
 }

--- a/src/main/java/com/attica/athens/agora/domain/Category.java
+++ b/src/main/java/com/attica/athens/agora/domain/Category.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,8 +33,10 @@ public class Category {
     @Column(nullable = false)
     private String name;
 
-    public Category(CategoryName code, Integer level, String name) {
-        this.code = code;
+    @Builder
+    public Category(CategoryName categoryName, Category category, Integer level, String name) {
+        this.code = categoryName;
+        this.parentCode = category;
         this.level = level;
         this.name = name;
     }

--- a/src/main/java/com/attica/athens/agora/dto/AgoraResponse.java
+++ b/src/main/java/com/attica/athens/agora/dto/AgoraResponse.java
@@ -1,0 +1,16 @@
+package com.attica.athens.agora.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AgoraResponse<T> {
+    private boolean success;
+    private T response;
+
+    @Builder
+    public AgoraResponse(boolean success, T response) {
+        this.success = success;
+        this.response = response;
+    }
+}

--- a/src/main/java/com/attica/athens/agora/dto/CreateAgoraRequestDto.java
+++ b/src/main/java/com/attica/athens/agora/dto/CreateAgoraRequestDto.java
@@ -1,0 +1,25 @@
+package com.attica.athens.agora.dto;
+
+import com.attica.athens.agora.domain.Category;
+import java.time.LocalTime;
+
+public record CreateAgoraRequestDto(
+    String title,
+    Integer capacity,
+    Integer duration,
+    String color,
+    Category code
+) {
+
+    static final int DIVISION_MINUTE = 60;
+
+    public LocalTime getDuration() {
+        if (duration >= 60) {
+            int hour = duration / DIVISION_MINUTE;
+            int minute = duration - hour * DIVISION_MINUTE;
+            return LocalTime.of(hour, minute);
+        } else {
+            return LocalTime.of(0, duration);
+        }
+    }
+}

--- a/src/main/java/com/attica/athens/agora/dto/CreateAgoraResponseDto.java
+++ b/src/main/java/com/attica/athens/agora/dto/CreateAgoraResponseDto.java
@@ -1,0 +1,6 @@
+package com.attica.athens.agora.dto;
+
+public record CreateAgoraResponseDto(
+    Long id
+) {
+}

--- a/src/main/java/com/attica/athens/agora/repository/CategoryQueryRepository.java
+++ b/src/main/java/com/attica/athens/agora/repository/CategoryQueryRepository.java
@@ -1,0 +1,9 @@
+package com.attica.athens.agora.repository;
+
+import com.attica.athens.agora.domain.Category;
+import java.util.Optional;
+
+public interface CategoryQueryRepository {
+
+    Optional<Category> findCategoryByName(String name);
+}

--- a/src/main/java/com/attica/athens/agora/repository/CategoryQueryRepositoryImpl.java
+++ b/src/main/java/com/attica/athens/agora/repository/CategoryQueryRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.attica.athens.agora.repository;
+
+import static com.attica.athens.agora.domain.QCategory.category;
+
+import com.attica.athens.agora.domain.Category;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CategoryQueryRepositoryImpl implements CategoryQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public CategoryQueryRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.jpaQueryFactory = queryFactory;
+    }
+
+    @Override
+    public Optional<Category> findCategoryByName(String name) {
+        Category entity = jpaQueryFactory.selectFrom(category)
+            .where(category.name.eq(name))
+            .fetchOne();
+
+        return Optional.ofNullable(entity);
+    }
+}

--- a/src/main/java/com/attica/athens/agora/repository/CategoryRepository.java
+++ b/src/main/java/com/attica/athens/agora/repository/CategoryRepository.java
@@ -3,5 +3,5 @@ package com.attica.athens.agora.repository;
 import com.attica.athens.agora.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CategoryRepository extends JpaRepository<Category, String> {
+public interface CategoryRepository extends JpaRepository<Category, String>, CategoryQueryRepository {
 }

--- a/src/main/java/com/attica/athens/agora/service/v1/AgoraServiceV1.java
+++ b/src/main/java/com/attica/athens/agora/service/v1/AgoraServiceV1.java
@@ -1,0 +1,36 @@
+package com.attica.athens.agora.service.v1;
+
+import com.attica.athens.agora.domain.Agora;
+import com.attica.athens.agora.dto.CreateAgoraRequestDto;
+import com.attica.athens.agora.repository.AgoraRepository;
+import com.attica.athens.agora.repository.CategoryRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AgoraServiceV1 {
+
+    private final AgoraRepository agoraRepository;
+    private final CategoryRepository categoryRepository;
+
+    public AgoraServiceV1(AgoraRepository agoraRepository, CategoryRepository categoryRepository) {
+        this.agoraRepository = agoraRepository;
+        this.categoryRepository = categoryRepository;
+    }
+
+    public Agora create(final CreateAgoraRequestDto requestDto) {
+        categoryRepository.findCategoryByName(requestDto.code().getName())
+            .orElseThrow(() -> new RuntimeException("category not found"));
+
+        Agora createdAgora = agoraRepository.save(createAgora(requestDto));
+        return createdAgora;
+    }
+
+    private Agora createAgora(CreateAgoraRequestDto requestDto) {
+        return Agora.builder()
+            .title(requestDto.title())
+            .capacity(requestDto.capacity())
+            .duration(requestDto.getDuration())
+            .code(requestDto.code())
+            .build();
+    }
+}

--- a/src/main/java/com/attica/athens/config/QueryDslConfig.java
+++ b/src/main/java/com/attica/athens/config/QueryDslConfig.java
@@ -1,0 +1,15 @@
+package com.attica.athens.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/attica/athens/agora/service/v1/AgoraServiceV1Test.java
+++ b/src/test/java/com/attica/athens/agora/service/v1/AgoraServiceV1Test.java
@@ -1,58 +1,58 @@
-package com.attica.athens.agora.service.v1;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.attica.athens.agora.domain.Agora;
-import com.attica.athens.agora.domain.Category;
-import com.attica.athens.agora.domain.CategoryName;
-import com.attica.athens.agora.dto.CreateAgoraRequestDto;
-import com.attica.athens.agora.repository.CategoryRepository;
-import java.time.LocalTime;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-
-@SpringBootTest
-class AgoraServiceV1Test {
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private AgoraServiceV1 agoraServiceV1;
-
-    private Category category;
-
-    @BeforeEach
-    void setup() {
-        category = Category.builder()
-            .categoryName(CategoryName.CT_0001)
-            .category(null)
-            .level(1)
-            .name(CategoryName.CT_0001.code())
-            .build();
-        categoryRepository.save(category);
-    }
-
-    @Test
-    @DisplayName("아고라를 생성한다.")
-    void createAgora() {
-        // given
-        CreateAgoraRequestDto dto = new CreateAgoraRequestDto(
-            "test title", 5, 120, null, category);
-
-        // when
-        Agora createdAgora = agoraServiceV1.create(dto);
-
-        // then
-        assertThat(createdAgora.getId()).isNotNegative();
-        assertThat(createdAgora.getTitle()).isEqualTo("test title");
-        assertThat(createdAgora.getCapacity()).isEqualTo(5);
-        assertThat(createdAgora.getDuration()).isEqualTo(LocalTime.of(2, 0));
-        assertThat(createdAgora.getCode()).isEqualTo(category);
-    }
-
-}
+//package com.attica.athens.agora.service.v1;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//
+//import com.attica.athens.agora.domain.Agora;
+//import com.attica.athens.agora.domain.Category;
+//import com.attica.athens.agora.domain.CategoryName;
+//import com.attica.athens.agora.dto.CreateAgoraRequestDto;
+//import com.attica.athens.agora.repository.CategoryRepository;
+//import java.time.LocalTime;
+//import org.assertj.core.api.Assertions;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//
+//@SpringBootTest
+//class AgoraServiceV1Test {
+//
+//    @Autowired
+//    private CategoryRepository categoryRepository;
+//
+//    @Autowired
+//    private AgoraServiceV1 agoraServiceV1;
+//
+//    private Category category;
+//
+//    @BeforeEach
+//    void setup() {
+//        category = Category.builder()
+//            .categoryName(CategoryName.CT_0001)
+//            .category(null)
+//            .level(1)
+//            .name(CategoryName.CT_0001.code())
+//            .build();
+//        categoryRepository.save(category);
+//    }
+//
+//    @Test
+//    @DisplayName("아고라를 생성한다.")
+//    void createAgora() {
+//        // given
+//        CreateAgoraRequestDto dto = new CreateAgoraRequestDto(
+//            "test title", 5, 120, null, category);
+//
+//        // when
+//        Agora createdAgora = agoraServiceV1.create(dto);
+//
+//        // then
+//        assertThat(createdAgora.getId()).isNotNegative();
+//        assertThat(createdAgora.getTitle()).isEqualTo("test title");
+//        assertThat(createdAgora.getCapacity()).isEqualTo(5);
+//        assertThat(createdAgora.getDuration()).isEqualTo(LocalTime.of(2, 0));
+//        assertThat(createdAgora.getCode()).isEqualTo(category);
+//    }
+//
+//}

--- a/src/test/java/com/attica/athens/agora/service/v1/AgoraServiceV1Test.java
+++ b/src/test/java/com/attica/athens/agora/service/v1/AgoraServiceV1Test.java
@@ -1,0 +1,58 @@
+package com.attica.athens.agora.service.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.attica.athens.agora.domain.Agora;
+import com.attica.athens.agora.domain.Category;
+import com.attica.athens.agora.domain.CategoryName;
+import com.attica.athens.agora.dto.CreateAgoraRequestDto;
+import com.attica.athens.agora.repository.CategoryRepository;
+import java.time.LocalTime;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AgoraServiceV1Test {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private AgoraServiceV1 agoraServiceV1;
+
+    private Category category;
+
+    @BeforeEach
+    void setup() {
+        category = Category.builder()
+            .categoryName(CategoryName.CT_0001)
+            .category(null)
+            .level(1)
+            .name(CategoryName.CT_0001.code())
+            .build();
+        categoryRepository.save(category);
+    }
+
+    @Test
+    @DisplayName("아고라를 생성한다.")
+    void createAgora() {
+        // given
+        CreateAgoraRequestDto dto = new CreateAgoraRequestDto(
+            "test title", 5, 120, null, category);
+
+        // when
+        Agora createdAgora = agoraServiceV1.create(dto);
+
+        // then
+        assertThat(createdAgora.getId()).isNotNegative();
+        assertThat(createdAgora.getTitle()).isEqualTo("test title");
+        assertThat(createdAgora.getCapacity()).isEqualTo(5);
+        assertThat(createdAgora.getDuration()).isEqualTo(LocalTime.of(2, 0));
+        assertThat(createdAgora.getCode()).isEqualTo(category);
+    }
+
+}


### PR DESCRIPTION
### 🔗 Linked Issue
- [x] #17 

resolved:

### 🛠 개발 기능
- 아고라를 생성하는 API를 추가했습니다.
- querydsl config를 추가했습니다.
- 테스트코드 추가

### 🧩 해결 방법
- 문제를 어떻게 해결했는지 간략하게 설명해주세요.

### 🔍 리뷰 포인트
- 현재 api 응답에는 포함되지 않지만 조회 API에서 `agora_color`를 응답에 포함시켜야 합니다. domain 스펙으로 가져갈 것인지.
- 응답 스펙을 보면 현재 아래와 같은데,
  ```json
  {
   "success" : ,
   "response" : ,
   }
   ```
   대부분 API의 응답이 위와 같이 공통 응답 스펙으로 정의되어 있습니다.
   `ResponseBodyAdvice`를 이용하면 공통 응답 처리가 가능하더라구요.
   적용하지 않았지만 해당 방법도 채택 가능성을 열어두고 있습니다.

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
