### PR TITLE
관찰자 권한 조정

### DIFF
--- a/src/main/java/com/attica/athens/domain/agora/application/AgoraService.java
+++ b/src/main/java/com/attica/athens/domain/agora/application/AgoraService.java
@@ -3,6 +3,7 @@ package com.attica.athens.domain.agora.application;
 import com.attica.athens.domain.agora.dao.AgoraRepository;
 import com.attica.athens.domain.agora.dao.CategoryRepository;
 import com.attica.athens.domain.agora.domain.Agora;
+import com.attica.athens.domain.agora.domain.AgoraStatus;
 import com.attica.athens.domain.agora.domain.Category;
 import com.attica.athens.domain.agora.dto.SimpleAgoraResult;
 import com.attica.athens.domain.agora.dto.request.AgoraCreateRequest;
@@ -23,6 +24,8 @@ import com.attica.athens.domain.agora.exception.DuplicatedNicknameException;
 import com.attica.athens.domain.agora.exception.FullAgoraCapacityException;
 import com.attica.athens.domain.agora.exception.NotFoundAgoraException;
 import com.attica.athens.domain.agora.exception.NotFoundCategoryException;
+import com.attica.athens.domain.agora.exception.NotParticipateException;
+import com.attica.athens.domain.agora.exception.ObserverException;
 import com.attica.athens.domain.agoraUser.dao.AgoraUserRepository;
 import com.attica.athens.domain.agoraUser.domain.AgoraUser;
 import com.attica.athens.domain.agoraUser.domain.AgoraUserType;
@@ -175,6 +178,8 @@ public class AgoraService {
             throw new NotFoundAgoraUserException(agoraId, userId);
         }
 
+        findAgoraUserByAgoraIdAndUserId(agoraId, userId);
+
         agora.startAgora();
 
         sendAgoraStartMessage(agora);
@@ -208,7 +213,9 @@ public class AgoraService {
         int participantCount = agoraUserRepository.countByAgoraId(agoraId);
         agora.endVoteAgora(participantCount);
 
-        sendAgoraEndMessage(agora);
+        if (agora.getStatus() == AgoraStatus.CLOSED) {
+            sendAgoraEndMessage(agora);
+        }
 
         return new EndVoteAgoraResponse(agora);
     }
@@ -223,7 +230,13 @@ public class AgoraService {
 
     private AgoraUser findAgoraUserByAgoraIdAndUserId(Long agoraId, Long userId) {
         return agoraUserRepository.findByAgoraIdAndUserId(agoraId, userId)
-                .orElseThrow(() -> new NotFoundAgoraUserException(agoraId, userId));
+                .map(agoraUser -> {
+                    if (agoraUser.getType() == AgoraUserType.OBSERVER) {
+                        throw new ObserverException();
+                    }
+                    return agoraUser;
+                })
+                .orElseThrow(NotParticipateException::new);
     }
 
     private void sendAgoraEndMessage(Agora agora) {

--- a/src/main/java/com/attica/athens/domain/agora/dto/response/EndVoteAgoraResponse.java
+++ b/src/main/java/com/attica/athens/domain/agora/dto/response/EndVoteAgoraResponse.java
@@ -9,6 +9,6 @@ public record EndVoteAgoraResponse(Long agoraId, Integer endVoteCount, Boolean i
 
     public EndVoteAgoraResponse(Agora agora) {
         this(agora.getId(), agora.getEndVoteCount(), agora.getStatus() == AgoraStatus.CLOSED,
-                format(agora.getEndTime()));
+                agora.getEndTime() == null ? null : format(agora.getEndTime()));
     }
 }

--- a/src/main/java/com/attica/athens/domain/agora/exception/NotParticipateException.java
+++ b/src/main/java/com/attica/athens/domain/agora/exception/NotParticipateException.java
@@ -10,7 +10,7 @@ public class NotParticipateException extends CustomException {
         super(
                 HttpStatus.BAD_REQUEST,
                 ErrorCode.WRONG_REQUEST_TRANSMISSION,
-                "User is not in the agora."
+                "User is not participating in the agora"
         );
     }
 }

--- a/src/main/java/com/attica/athens/domain/agora/exception/ObserverException.java
+++ b/src/main/java/com/attica/athens/domain/agora/exception/ObserverException.java
@@ -1,0 +1,16 @@
+package com.attica.athens.domain.agora.exception;
+
+import com.attica.athens.domain.common.advice.CustomException;
+import com.attica.athens.domain.common.advice.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class ObserverException extends CustomException {
+
+    public ObserverException() {
+        super(
+                HttpStatus.FORBIDDEN,
+                ErrorCode.RESOURCE_ACCESS_FORBIDDEN,
+                "observer cannot send this request"
+        );
+    }
+}

--- a/src/main/java/com/attica/athens/domain/chat/application/ChatCommandService.java
+++ b/src/main/java/com/attica/athens/domain/chat/application/ChatCommandService.java
@@ -3,8 +3,10 @@ package com.attica.athens.domain.chat.application;
 import com.attica.athens.domain.agora.dao.AgoraRepository;
 import com.attica.athens.domain.agora.exception.NotFoundAgoraException;
 import com.attica.athens.domain.agora.exception.NotParticipateException;
+import com.attica.athens.domain.agora.exception.ObserverException;
 import com.attica.athens.domain.agoraUser.dao.AgoraUserRepository;
 import com.attica.athens.domain.agoraUser.domain.AgoraUser;
+import com.attica.athens.domain.agoraUser.domain.AgoraUserType;
 import com.attica.athens.domain.chat.dao.ChatRepository;
 import com.attica.athens.domain.chat.domain.Chat;
 import com.attica.athens.domain.chat.dto.request.SendChatRequest;
@@ -44,6 +46,12 @@ public class ChatCommandService {
 
     private AgoraUser findAgoraUserByAgoraIdAndUserId(Long agoraId, Long userId) {
         return agoraUserRepository.findByAgoraIdAndUserId(agoraId, userId)
+                .map(agoraUser -> {
+                    if (agoraUser.getType() == AgoraUserType.OBSERVER) {
+                        throw new ObserverException();
+                    }
+                    return agoraUser;
+                })
                 .orElseThrow(NotParticipateException::new);
     }
 

--- a/src/main/java/com/attica/athens/global/handler/StompErrorHandler.java
+++ b/src/main/java/com/attica/athens/global/handler/StompErrorHandler.java
@@ -38,20 +38,19 @@ public class StompErrorHandler extends StompSubProtocolErrorHandler {
             if (cause instanceof InvalidAuthorizationHeaderException) {
                 return sendErrorMessage(new ErrorResponse(1003, cause.getMessage()));
             }
-            if (cause instanceof JwtSignatureException) {
-                return sendErrorMessage(new ErrorResponse(1201, cause.getMessage()));
-            }
-            if (cause instanceof JwtExpiredException) {
-                return sendErrorMessage(new ErrorResponse(1201, cause.getMessage()));
-            }
-            if (cause instanceof JwtUnsupportedJwtException) {
-                return sendErrorMessage(new ErrorResponse(1201, cause.getMessage()));
-            }
-            if (cause instanceof JwtIllegalArgumentException) {
+
+            if (isJwtException(cause)) {
                 return sendErrorMessage(new ErrorResponse(1201, cause.getMessage()));
             }
         }
         return super.handleClientMessageProcessingError(clientMessage, ex);
+    }
+
+    private boolean isJwtException(Throwable ex) {
+        return ex instanceof JwtSignatureException
+                || ex instanceof JwtExpiredException
+                || ex instanceof JwtUnsupportedJwtException
+                || ex instanceof JwtIllegalArgumentException;
     }
 
     private Message<byte[]> sendErrorMessage(ErrorResponse errorResponse) {


### PR DESCRIPTION
### 🔗 Linked Issue
- [ ] #99

### 🛠 개발 기능
- 관찰자는 채팅을 전송하지 못하도록 제한합니다.
- 관찰자는 토론 시작, 종료 투표를 못하도록 제한합니다.
+ 추가로 StompErrorHandler 리팩토링 수행했습니다.

### 🧩 해결 방법
- 관찰자일 경우 예외를 발생시켰습니다. API 문서에 정리해두었어요.

### 🔍 리뷰 포인트
- 적절히 예외 처리가 되었는지 확인 부탁드려요.



<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
