### PR TITLE
fix: 채팅 사용자 조회하기 실시간 참여자만 조회되도록 수정

### DIFF
--- a/src/main/java/com/attica/athens/domain/agoraUser/dao/AgoraUserRepository.java
+++ b/src/main/java/com/attica/athens/domain/agoraUser/dao/AgoraUserRepository.java
@@ -26,7 +26,7 @@ public interface AgoraUserRepository extends JpaRepository<AgoraUser, Integer>, 
 
     List<AgoraUser> findByAgoraId(Long agoraId);
 
-    List<AgoraUser> findByAgoraIdAndTypeIn(Long agoraId, List<AgoraUserType> types);
+    List<AgoraUser> findByAgoraIdAndTypeInAndSessionIdIsNotNull(Long agoraId, List<AgoraUserType> types);
 
     int countByAgoraId(Long agoraId);
 

--- a/src/main/java/com/attica/athens/domain/chat/application/ChatQueryService.java
+++ b/src/main/java/com/attica/athens/domain/chat/application/ChatQueryService.java
@@ -107,7 +107,7 @@ public class ChatQueryService {
     }
 
     private List<AgoraUser> findByAgoraIdAndTypeIn(Long agoraId) {
-        return agoraUserRepository.findByAgoraIdAndTypeIn(agoraId,
+        return agoraUserRepository.findByAgoraIdAndTypeInAndSessionIdIsNotNull(agoraId,
                 Arrays.asList(AgoraUserType.PROS, AgoraUserType.CONS));
     }
 }


### PR DESCRIPTION
### 🛠 개발 기능
- 채팅 사용자 조회하기에서 실시간으로 연결된 유저만 조회되도록 수정했습니다.

### 🧩 해결 방법
- 사용자가 현재 sessionId를 가진 연결된 사용자일 경우 조회되도록 수정했습니다.


<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
