### PR TITLE
메타정보 조회 websocket 테스트 코드 작성

### DIFF
--- a/src/test/java/com/attica/athens/domain/agora/AgoraWebSocketApiintegerationTest.java
+++ b/src/test/java/com/attica/athens/domain/agora/AgoraWebSocketApiintegerationTest.java
@@ -1,0 +1,71 @@
+package com.attica.athens.domain.agora;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.attica.athens.support.WebSocketIntegrationTestSupport;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.test.context.jdbc.Sql;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(Lifecycle.PER_CLASS)
+public class AgoraWebSocketApiintegerationTest extends WebSocketIntegrationTestSupport {
+
+    private final String CHAT_TOPIC_URL = "/topic/agoras/{agoraId}/chats";
+    private final String META_TOPIC_URL = "/topic/agoras/{agoraId}";
+
+    @BeforeAll
+    void setup() {
+        setupStompClient();
+    }
+
+    @Test
+    @Sql("/sql/send-valid-chat.sql")
+    @DisplayName("아고라에 다른 사용자가 입장하면 아고라에 참여하는 유저는 업데이트된 메타 정보를 받는다")
+    void 성공_아고라입장_유효한AgoraId() throws Exception {
+        // given
+        Long agoraId = 1L;
+        String metaTopicUrl = META_TOPIC_URL.replace("{agoraId}", agoraId.toString());
+        CompletableFuture<String> resultFuture = new CompletableFuture<>();
+        connectAndSubscribe(metaTopicUrl, "EnvironmentalActivist", agoraId, resultFuture);
+
+        // when
+        String url = CHAT_TOPIC_URL.replace("{agoraId}", agoraId.toString());
+        CompletableFuture<String> chatResultFuture = new CompletableFuture<>();
+        connectAndSubscribe(url, "PolicyExpert", agoraId, chatResultFuture);
+
+        // then
+        String result = resultFuture.get(15, TimeUnit.SECONDS);
+        assertThat(result).contains(
+                "participants\":[{\"type\":\"OBSERVER\",\"count\":1},{\"type\":\"PROS\",\"count\":1}]");
+    }
+
+    @Test
+    @Sql("/sql/send-valid-chat.sql")
+    @DisplayName("아고라에 다른 사용자가 퇴장하면 아고라에 참여하는 유저는 업데이트된 메타 정보를 받는다")
+    void 성공_아고라퇴장_유효한AgoraId() throws Exception {
+        // given
+        Long agoraId = 1L;
+        String url = CHAT_TOPIC_URL.replace("{agoraId}", agoraId.toString());
+        CompletableFuture<String> chatResultFuture = new CompletableFuture<>();
+        final StompSession session = connectAndSubscribe(url, "PolicyExpert", agoraId, chatResultFuture);
+
+        String metaTopicUrl = META_TOPIC_URL.replace("{agoraId}", agoraId.toString());
+        CompletableFuture<String> resultFuture = new CompletableFuture<>();
+        connectAndSubscribe(metaTopicUrl, "EnvironmentalActivist", agoraId, resultFuture);
+
+        // when
+        session.disconnect();
+
+        // then
+        String result = resultFuture.get(15, TimeUnit.SECONDS);
+        assertThat(result).contains("participants\":[{\"type\":\"PROS\",\"count\":1}]");
+    }
+}

--- a/src/test/java/com/attica/athens/domain/chat/ChatOpenApiIntegrationTest.java
+++ b/src/test/java/com/attica/athens/domain/chat/ChatOpenApiIntegrationTest.java
@@ -22,16 +22,16 @@ public class ChatOpenApiIntegrationTest extends IntegrationTestSupport {
         @Test
         @DisplayName("채팅 내역을 조회한다")
         void 성공_채팅조회_유효한AgoraId() throws Exception {
-            // Given
+            // given
 
-            // When
+            // when
             final ResultActions result = mockMvc.perform(
                     get("/{prefix}/agoras/{agoraId}/chats", API_V1_OPEN, 1)
                             .contentType(MediaType.APPLICATION_JSON)
 
             );
 
-            // Then
+            // then
             result.andExpect(status().isOk())
                     .andExpectAll(
                             jsonPath("$.success").value(true),
@@ -54,16 +54,16 @@ public class ChatOpenApiIntegrationTest extends IntegrationTestSupport {
         @DisplayName("채팅방 참여자를 조회한다")
         @Sql("/sql/enter-agora-members.sql")
         void 성공_참여자조회_유효한AgoraId() throws Exception {
-            // Given
+            // given
 
-            // When
+            // when
             final ResultActions result = mockMvc.perform(
                     get("/{prefix}/agoras/{agoraId}/users", API_V1_OPEN, 1)
                             .contentType(MediaType.APPLICATION_JSON)
 
             );
 
-            // Then
+            // then
             result.andExpect(status().isOk())
                     .andExpectAll(
                             jsonPath("$.success").value(true),
@@ -81,16 +81,16 @@ public class ChatOpenApiIntegrationTest extends IntegrationTestSupport {
         @Test
         @DisplayName("유효하지 않은 아고라 아이디로 채팅방 참여자를 조회한다")
         void 실패_참여자조회_유효하지않은AgoraId() throws Exception {
-            // Given
+            // given
 
-            // When
+            // when
             final ResultActions result = mockMvc.perform(
                     get("/{prefix}/agoras/{agoraId}/users", API_V1_OPEN, 999)
                             .contentType(MediaType.APPLICATION_JSON)
 
             );
 
-            // Then
+            // then
             result.andExpect(status().isNotFound())
                     .andExpectAll(
                             jsonPath("$.success").value(false),

--- a/src/test/java/com/attica/athens/domain/chat/ChatWebSocketApiIntegrationTest.java
+++ b/src/test/java/com/attica/athens/domain/chat/ChatWebSocketApiIntegrationTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.attica.athens.domain.chat.domain.ChatType;
 import com.attica.athens.domain.chat.dto.request.SendChatRequest;
-import com.attica.athens.domain.chat.dto.response.ErrorResponse;
-import com.attica.athens.domain.chat.dto.response.SendChatResponse;
 import com.attica.athens.support.WebSocketIntegrationTestSupport;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -41,18 +39,17 @@ class ChatWebSocketApiIntegrationTest extends WebSocketIntegrationTestSupport {
         @DisplayName("유효한 메시지를 전송하면 성공적으로 채팅이 전송된다")
         @Sql("/sql/send-valid-chat.sql")
         void 성공_채팅생성_유효한파라미터사용() throws Exception {
-            // Given
+            // given
             Long agoraId = 1L;
             String url = CHAT_TOPIC_URL.replace("{agoraId}", agoraId.toString());
             CompletableFuture<String> resultFuture = new CompletableFuture<>();
-            StompSession session = connectAndSubscribe(url, "EnvironmentalActivist", agoraId, resultFuture,
-                    SendChatResponse.class);
+            StompSession session = connectAndSubscribe(url, "EnvironmentalActivist", agoraId, resultFuture);
 
-            // When
+            // when
             SendChatRequest chatRequest = new SendChatRequest(ChatType.CHAT, "안녕하세요.");
             session.send(CHAT_APP_URL.replace("{agoraId}", agoraId.toString()), chatRequest);
 
-            // Then
+            // then
             String result = resultFuture.get(10, TimeUnit.SECONDS);
             assertThat(result).contains("안녕하세요.");
         }
@@ -61,23 +58,22 @@ class ChatWebSocketApiIntegrationTest extends WebSocketIntegrationTestSupport {
         @DisplayName("10000자를 초과하는 메시지를 작성하면 에러를 반환한다")
         @Sql("/sql/send-valid-chat.sql")
         void 실패_채팅전송_메시지길이초과() throws Exception {
-            // Given
+            // given
             Long agoraId = 1L;
             CompletableFuture<String> resultFuture = new CompletableFuture<>();
-            StompSession session = connectAndSubscribe(ERROR_URL, "EnvironmentalActivist", agoraId, resultFuture,
-                    ErrorResponse.class);
+            StompSession session = connectAndSubscribe(ERROR_URL, "EnvironmentalActivist", agoraId, resultFuture);
 
-            // When
+            // when
             String longMessage = "a".repeat(10001);
             SendChatRequest chatRequest = new SendChatRequest(ChatType.CHAT, longMessage);
             session.send(CHAT_APP_URL.replace("{agoraId}", agoraId.toString()), chatRequest);
 
-            // Then
+            // then
             String result = resultFuture.get(10, TimeUnit.SECONDS);
             assertAll(() -> {
                 assertThat(result).contains("ERROR");
                 assertThat(result).contains("1001");
-                assertThat(result).contains("message=Content length exceeds maximum limit of 10000 characters");
+                assertThat(result).contains("Content length exceeds maximum limit of 10000 characters");
             });
         }
 
@@ -85,17 +81,16 @@ class ChatWebSocketApiIntegrationTest extends WebSocketIntegrationTestSupport {
         @DisplayName("type을 입력하지않으면 에러를 반환한다")
         @Sql("/sql/send-valid-chat.sql")
         void 실패_채팅전송_type미입력() throws Exception {
-            // Given
+            // given
             Long agoraId = 1L;
             CompletableFuture<String> resultFuture = new CompletableFuture<>();
-            StompSession session = connectAndSubscribe(ERROR_URL, "EnvironmentalActivist", agoraId, resultFuture,
-                    ErrorResponse.class);
+            StompSession session = connectAndSubscribe(ERROR_URL, "EnvironmentalActivist", agoraId, resultFuture);
 
-            // When
+            // when
             SendChatRequest chatRequest = new SendChatRequest(null, "안녕하세요.");
             session.send(CHAT_APP_URL.replace("{agoraId}", agoraId.toString()), chatRequest);
 
-            // Then
+            // then
             String result = resultFuture.get(10, TimeUnit.SECONDS);
             assertAll(() -> {
                 assertThat(result).contains("ERROR");
@@ -108,17 +103,16 @@ class ChatWebSocketApiIntegrationTest extends WebSocketIntegrationTestSupport {
         @DisplayName("빈 메세지를 입력하면 에러를 반환한다")
         @Sql("/sql/send-valid-chat.sql")
         void 실패_채팅전송_빈메세지() throws Exception {
-            // Given
+            // given
             Long agoraId = 1L;
             CompletableFuture<String> resultFuture = new CompletableFuture<>();
-            StompSession session = connectAndSubscribe(ERROR_URL, "EnvironmentalActivist", agoraId, resultFuture,
-                    ErrorResponse.class);
+            StompSession session = connectAndSubscribe(ERROR_URL, "EnvironmentalActivist", agoraId, resultFuture);
 
-            // When
+            // when
             SendChatRequest chatRequest = new SendChatRequest(ChatType.CHAT, "");
             session.send(CHAT_APP_URL.replace("{agoraId}", agoraId.toString()), chatRequest);
 
-            // Then
+            // then
             String result = resultFuture.get(10, TimeUnit.SECONDS);
             assertAll(() -> {
                 assertThat(result).contains("ERROR");
@@ -131,17 +125,16 @@ class ChatWebSocketApiIntegrationTest extends WebSocketIntegrationTestSupport {
         @DisplayName("존재하지 않는 아고라 id를 입력하면 에러를 반환한다")
         @Sql("/sql/send-valid-chat.sql")
         void 실패_채팅전송_존재하지않은AgoraId() throws Exception {
-            // Given
+            // given
             Long agoraId = 9999L;
             CompletableFuture<String> resultFuture = new CompletableFuture<>();
-            StompSession session = connectAndSubscribe(ERROR_URL, "EnvironmentalActivist", agoraId, resultFuture,
-                    ErrorResponse.class);
+            StompSession session = connectAndSubscribe(ERROR_URL, "EnvironmentalActivist", agoraId, resultFuture);
 
-            // When
+            // when
             SendChatRequest chatRequest = new SendChatRequest(ChatType.CHAT, "안녕하세요.");
             session.send(CHAT_APP_URL.replace("{agoraId}", agoraId.toString()), chatRequest);
 
-            // Then
+            // then
             String result = resultFuture.get(10, TimeUnit.SECONDS);
             assertAll(() -> {
                 assertThat(result).contains("ERROR");
@@ -154,17 +147,16 @@ class ChatWebSocketApiIntegrationTest extends WebSocketIntegrationTestSupport {
         @DisplayName("유저가 아고라에 참여하지 않은 경우 에러를 반환한다")
         @Sql("/sql/send-valid-chat.sql")
         void 실패_채팅전송_비참여유저() throws Exception {
-            // Given
+            // given
             Long agoraId = 1L;
             CompletableFuture<String> resultFuture = new CompletableFuture<>();
-            StompSession session = connectAndSubscribe(ERROR_URL, "TeacherUnion", agoraId, resultFuture,
-                    ErrorResponse.class);
+            StompSession session = connectAndSubscribe(ERROR_URL, "TeacherUnion", agoraId, resultFuture);
 
-            // When
+            // when
             SendChatRequest chatRequest = new SendChatRequest(ChatType.CHAT, "안녕하세요.");
             session.send(CHAT_APP_URL.replace("{agoraId}", agoraId.toString()), chatRequest);
 
-            // Then
+            // then
             String result = resultFuture.get(10, TimeUnit.SECONDS);
             assertAll(() -> {
                 assertThat(result).contains("ERROR");
@@ -177,17 +169,16 @@ class ChatWebSocketApiIntegrationTest extends WebSocketIntegrationTestSupport {
         @DisplayName("유저가 관찰자일 경우 에러를 반환한다")
         @Sql("/sql/send-valid-chat.sql")
         void 실패_채팅전송_관찰자() throws Exception {
-            // Given
+            // given
             Long agoraId = 1L;
             CompletableFuture<String> resultFuture = new CompletableFuture<>();
-            StompSession session = connectAndSubscribe(ERROR_URL, "PolicyExpert", agoraId, resultFuture,
-                    ErrorResponse.class);
+            StompSession session = connectAndSubscribe(ERROR_URL, "PolicyExpert", agoraId, resultFuture);
 
-            // When
+            // when
             SendChatRequest chatRequest = new SendChatRequest(ChatType.CHAT, "안녕하세요.");
             session.send(CHAT_APP_URL.replace("{agoraId}", agoraId.toString()), chatRequest);
 
-            // Then
+            // then
             String result = resultFuture.get(10, TimeUnit.SECONDS);
             assertAll(() -> {
                 assertThat(result).contains("ERROR");

--- a/src/test/java/com/attica/athens/support/WebSocketIntegrationTestSupport.java
+++ b/src/test/java/com/attica/athens/support/WebSocketIntegrationTestSupport.java
@@ -70,13 +70,13 @@ public abstract class WebSocketIntegrationTestSupport extends IntegrationTestSup
         ).get(3, TimeUnit.SECONDS);
     }
 
-    private <T> void subscribeToTopic(final String topic, final StompSession session,
+    private void subscribeToTopic(final String topic, final StompSession session,
                                       CompletableFuture<String> resultFuture) {
         session.subscribe(topic,
                 createStompFrameHandler(resultFuture));
     }
 
-    private <T> StompFrameHandler createStompFrameHandler(CompletableFuture<String> resultFuture) {
+    private StompFrameHandler createStompFrameHandler(CompletableFuture<String> resultFuture) {
         return new StompFrameHandler() {
             @Override
             public Type getPayloadType(StompHeaders headers) {

--- a/src/test/java/com/attica/athens/support/WebSocketIntegrationTestSupport.java
+++ b/src/test/java/com/attica/athens/support/WebSocketIntegrationTestSupport.java
@@ -4,6 +4,7 @@ import com.attica.athens.config.TestSecurityConfig.TestCustomUserDetailsServiceC
 import com.attica.athens.global.auth.CustomUserDetails;
 import com.attica.athens.global.auth.jwt.JwtUtils;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,10 +43,10 @@ public abstract class WebSocketIntegrationTestSupport extends IntegrationTestSup
     }
 
     protected StompSession connectAndSubscribe(final String topic, final String username, final Long agoraId,
-                                               final CompletableFuture<String> resultFuture, Class<?> payloadType
+                                               final CompletableFuture<String> resultFuture
     ) throws Exception {
         StompSession session = connectToWebSocket(username, agoraId);
-        subscribeToTopic(topic, session, resultFuture, payloadType);
+        subscribeToTopic(topic, session, resultFuture);
         return session;
     }
 
@@ -70,24 +71,27 @@ public abstract class WebSocketIntegrationTestSupport extends IntegrationTestSup
     }
 
     private <T> void subscribeToTopic(final String topic, final StompSession session,
-                                      CompletableFuture<String> resultFuture, Class<T> payloadType) {
+                                      CompletableFuture<String> resultFuture) {
         session.subscribe(topic,
-                createStompFrameHandler(payloadType, resultFuture));
+                createStompFrameHandler(resultFuture));
     }
 
-    private <T> StompFrameHandler createStompFrameHandler(Class<T> payloadType,
-                                                          CompletableFuture<String> resultFuture) {
+    private <T> StompFrameHandler createStompFrameHandler(CompletableFuture<String> resultFuture) {
         return new StompFrameHandler() {
             @Override
             public Type getPayloadType(StompHeaders headers) {
-                return payloadType;
+                return byte[].class;
             }
 
             @Override
             public void handleFrame(StompHeaders headers, Object payload) {
                 try {
-                    T typedPayload = payloadType.cast(payload);
-                    resultFuture.complete(typedPayload.toString());
+                    if (payload instanceof byte[]) {
+                        String strPayload = new String((byte[]) payload, StandardCharsets.UTF_8);
+                        resultFuture.complete(strPayload);
+                    } else {
+                        resultFuture.completeExceptionally(new IllegalArgumentException("Unexpected payload type"));
+                    }
                 } catch (Exception e) {
                     resultFuture.completeExceptionally(e);
                 }


### PR DESCRIPTION
### 🔗 Linked Issue
- [ ] #67 

resolved: #67 

### 🛠 개발 기능
- 사용자가 아고라에 입장하거나 퇴장시에 아고라에 참여한 유저들에게 알림(웹소켓 메세지)이 가는 부분 테스트 코드를 작성했습니다.

### 🧩 해결 방법
- 웹소켓 메세지가 클 경우 chunk로 나누어서 오기 때문에 응답 메세지 타입이 예상했던 응답 타입과 달랐습니다.
  - `StompFrameHandler`의 `getPayloadType`에서 반환하는 예상된 메세지 타입이 아니므로 타임아웃 예외가 발생했습니다.  
  - 메세지를 `byte[]`로 받아 범용적으로 처리하니 예상대로 응답을 잘 받아올 수 있었습니다.

### 🔍 리뷰 포인트
- 입장, 퇴장시 메세지를 보내 받는 로직이라 실패 경우가 떠오르지 않아 성공 테스트만 작성했습니다.
- 실패 경우가 있다면 알려주시면 테스트 코드에 추가하겠습니다.

리뷰 감사합니다 👍

<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
