### PR TITLE
비속어 필터 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'org.springframework:spring-aop'
 
+    implementation 'org.ahocorasick:ahocorasick:0.6.3'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2'

--- a/src/main/java/com/attica/athens/domain/agora/application/AgoraService.java
+++ b/src/main/java/com/attica/athens/domain/agora/application/AgoraService.java
@@ -102,8 +102,7 @@ public class AgoraService {
     @Transactional
     public AgoraParticipateResponse participate(final Long memberId, final Long agoraId,
                                                 final AgoraParticipateRequest request) {
-        Agora agora = agoraRepository.findAgoraById(agoraId)
-                .orElseThrow(() -> new NotFoundAgoraException(agoraId));
+        Agora agora = findAgoraById(agoraId);
 
         if (!Objects.equals(AgoraMemberType.OBSERVER, request.type())) {
             int typeCount = agoraMemberRepository.countCapacityByAgoraMemberType(agora.getId(), request.type());
@@ -132,8 +131,7 @@ public class AgoraService {
 
     @Transactional
     public AgoraExitResponse exit(final Long memberId, final Long agoraId) {
-        Agora agora = agoraRepository.findAgoraById(agoraId)
-                .orElseThrow(() -> new NotFoundAgoraException(agoraId));
+        findAgoraById(agoraId);
 
         AgoraMember agoraMember = agoraMemberService.findAgoraMemberByAgoraIdAndMemberId(agoraId, memberId);
         LocalDateTime socketDisconnectTime = LocalDateTime.now();
@@ -141,7 +139,7 @@ public class AgoraService {
         agoraMember.updateSocketDisconnectTime(socketDisconnectTime);
         agoraMember.updateDisconnectType(true);
 
-        return new AgoraExitResponse(agora.getId(), memberId, agoraMember.getType(), socketDisconnectTime);
+        return new AgoraExitResponse(memberId, agoraMember.getType(), socketDisconnectTime);
     }
 
     public List<SimpleAgoraResult> findTrendAgora() {

--- a/src/main/java/com/attica/athens/domain/agora/application/AgoraService.java
+++ b/src/main/java/com/attica/athens/domain/agora/application/AgoraService.java
@@ -65,7 +65,6 @@ public class AgoraService {
     private final AgoraMemberService agoraMemberService;
     private final PopularRepository popularRepository;
 
-
     @Transactional
     public CreateAgoraResponse create(final AgoraCreateRequest request) {
         Category category = findByCategory(request.categoryId());

--- a/src/main/java/com/attica/athens/domain/agora/dto/response/AgoraExitResponse.java
+++ b/src/main/java/com/attica/athens/domain/agora/dto/response/AgoraExitResponse.java
@@ -4,7 +4,6 @@ import com.attica.athens.domain.agoraMember.domain.AgoraMemberType;
 import java.time.LocalDateTime;
 
 public record AgoraExitResponse(
-        Long agoraId,
         Long userId,
         AgoraMemberType type,
         LocalDateTime socketDisconnectTime

--- a/src/main/java/com/attica/athens/domain/agoraMember/dto/response/SendMetaResponse.java
+++ b/src/main/java/com/attica/athens/domain/agoraMember/dto/response/SendMetaResponse.java
@@ -18,7 +18,7 @@ public record SendMetaResponse(ChatType type, MetaData data) {
             AgoraInfo agora,
             AgoraMemberInfo agoraMemberInfo) {
         public MetaData(List<ParticipantsInfo> participants, Agora agora, AgoraMember agoraMember) {
-            this(participants, new AgoraInfo(agora), new AgoraMemberInfo(agora.getId(), agoraMember));
+            this(participants, new AgoraInfo(agora), new AgoraMemberInfo(agoraMember));
         }
     }
 
@@ -47,13 +47,12 @@ public record SendMetaResponse(ChatType type, MetaData data) {
     }
 
     public record AgoraMemberInfo(
-            Long agoraId,
             Long memberId,
             String username,
             LocalDateTime socketDisconnectTime
     ) {
-        public AgoraMemberInfo(Long agoraId, AgoraMember agoraMember) {
-            this(agoraId, agoraMember.getId(), agoraMember.getNickname(), agoraMember.getSocketDisconnectTime());
+        public AgoraMemberInfo(AgoraMember agoraMember) {
+            this(agoraMember.getId(), agoraMember.getNickname(), agoraMember.getSocketDisconnectTime());
         }
     }
 }

--- a/src/main/java/com/attica/athens/domain/chat/api/ChatAuthController.java
+++ b/src/main/java/com/attica/athens/domain/chat/api/ChatAuthController.java
@@ -9,11 +9,15 @@ import com.attica.athens.global.auth.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,5 +48,13 @@ public class ChatAuthController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return chatCommandService.sendReaction(userDetails, agoraId, chatId, sendReactionRequest);
+    }
+    @GetMapping("/agoras/{agoraId}/chats/filter")
+    public ResponseEntity<?> filterChat(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("agoraId") Long agoraId,
+            @RequestBody SendChatRequest sendChatRequest) {
+
+        return chatCommandService.checkBadWord(userDetails, agoraId, sendChatRequest);
     }
 }

--- a/src/main/java/com/attica/athens/domain/chat/application/ChatCommandService.java
+++ b/src/main/java/com/attica/athens/domain/chat/application/ChatCommandService.java
@@ -6,7 +6,7 @@ import com.attica.athens.domain.agora.exception.NotParticipateException;
 import com.attica.athens.domain.agoraMember.dao.AgoraMemberRepository;
 import com.attica.athens.domain.agoraMember.domain.AgoraMember;
 import com.attica.athens.domain.chat.component.BadWordFilter;
-import com.attica.athens.domain.chat.component.FilterResult;
+import com.attica.athens.domain.chat.domain.FilterResult;
 import com.attica.athens.domain.chat.dao.ChatRepository;
 import com.attica.athens.domain.chat.dao.ReactionRepository;
 import com.attica.athens.domain.chat.domain.Chat;
@@ -134,7 +134,6 @@ public class ChatCommandService {
 
     public ResponseEntity<?> checkBadWord(final CustomUserDetails userDetails, final Long agoraId,
                                           final SendChatRequest sendChatRequest) {
-        validateAgoraExists(agoraId);
         findValidAgoraMember(agoraId, userDetails.getUserId());
 
         FilterResult filter = badWordFilter.filter(sendChatRequest.message());

--- a/src/main/java/com/attica/athens/domain/chat/component/BadWordFilter.java
+++ b/src/main/java/com/attica/athens/domain/chat/component/BadWordFilter.java
@@ -1,0 +1,34 @@
+package com.attica.athens.domain.chat.component;
+
+import com.attica.athens.domain.chat.dao.BadWordRepository;
+import com.attica.athens.domain.chat.domain.BadWord;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.ahocorasick.trie.Emit;
+import org.ahocorasick.trie.Trie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BadWordFilter {
+    private final Trie trie;
+    private final BadWordRepository badWordRepository;
+
+    public BadWordFilter(BadWordRepository badWordRepository){
+        this.badWordRepository = badWordRepository;
+        this.trie = buildTrie();
+    }
+
+    private Trie buildTrie() {
+        List<String> badwords = badWordRepository.findAll()
+                .stream()
+                .map(BadWord::getWord)
+                .collect(Collectors.toList());
+        return Trie.builder().addKeywords(badwords).build();
+    }
+
+    public FilterResult filter(String text){
+        Collection<Emit> emits = trie.parseText(text);
+        return new FilterResult(text,emits);
+    }
+}

--- a/src/main/java/com/attica/athens/domain/chat/component/BadWordFilter.java
+++ b/src/main/java/com/attica/athens/domain/chat/component/BadWordFilter.java
@@ -2,6 +2,7 @@ package com.attica.athens.domain.chat.component;
 
 import com.attica.athens.domain.chat.dao.BadWordRepository;
 import com.attica.athens.domain.chat.domain.BadWord;
+import com.attica.athens.domain.chat.domain.FilterResult;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,11 +12,15 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class BadWordFilter {
-    private final Trie trie;
+    private Trie trie;
     private final BadWordRepository badWordRepository;
 
-    public BadWordFilter(BadWordRepository badWordRepository){
+    public BadWordFilter(BadWordRepository badWordRepository) {
         this.badWordRepository = badWordRepository;
+        init();
+    }
+
+    public void init() {
         this.trie = buildTrie();
     }
 
@@ -27,8 +32,8 @@ public class BadWordFilter {
         return Trie.builder().addKeywords(badwords).build();
     }
 
-    public FilterResult filter(String text){
+    public FilterResult filter(String text) {
         Collection<Emit> emits = trie.parseText(text);
-        return new FilterResult(text,emits);
+        return new FilterResult(text, emits);
     }
 }

--- a/src/main/java/com/attica/athens/domain/chat/component/FilterResult.java
+++ b/src/main/java/com/attica/athens/domain/chat/component/FilterResult.java
@@ -1,0 +1,22 @@
+package com.attica.athens.domain.chat.component;
+
+import java.util.Collection;
+import org.ahocorasick.trie.Emit;
+
+public class FilterResult {
+    private final String originalText;
+    private final Collection<Emit> badword;
+
+    public FilterResult(String originalText, Collection<Emit> badword) {
+        this.originalText = originalText;
+        this.badword = badword;
+    }
+
+    public String getOriginalText() {
+        return originalText;
+    }
+
+    public Collection<Emit> getBadword() {
+        return badword;
+    }
+}

--- a/src/main/java/com/attica/athens/domain/chat/dao/BadWordRepository.java
+++ b/src/main/java/com/attica/athens/domain/chat/dao/BadWordRepository.java
@@ -1,0 +1,7 @@
+package com.attica.athens.domain.chat.dao;
+
+import com.attica.athens.domain.chat.domain.BadWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BadWordRepository extends JpaRepository<BadWord,Long> {
+}

--- a/src/main/java/com/attica/athens/domain/chat/domain/BadWord.java
+++ b/src/main/java/com/attica/athens/domain/chat/domain/BadWord.java
@@ -1,0 +1,24 @@
+package com.attica.athens.domain.chat.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BadWord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "badword_id")
+    private Long id;
+
+    @Column(name = "word")
+    String word;
+}

--- a/src/main/java/com/attica/athens/domain/chat/domain/FilterResult.java
+++ b/src/main/java/com/attica/athens/domain/chat/domain/FilterResult.java
@@ -1,4 +1,4 @@
-package com.attica.athens.domain.chat.component;
+package com.attica.athens.domain.chat.domain;
 
 import java.util.Collection;
 import org.ahocorasick.trie.Emit;

--- a/src/main/java/com/attica/athens/domain/chat/dto/response/BadWordResponse.java
+++ b/src/main/java/com/attica/athens/domain/chat/dto/response/BadWordResponse.java
@@ -1,0 +1,15 @@
+package com.attica.athens.domain.chat.dto.response;
+
+import com.attica.athens.domain.chat.component.FilterResult;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record BadWordResponse(List<BadWordInfo> badword) {
+    public BadWordResponse(FilterResult filterResult) {
+        this(filterResult.getBadword().stream()
+                        .map(emit -> new BadWordInfo(emit.getStart(), emit.getEnd(), emit.getKeyword())).collect(
+                                Collectors.toList()));
+    }
+    public record BadWordInfo(int start, int end, String keyword) {
+    }
+}

--- a/src/main/java/com/attica/athens/domain/chat/dto/response/BadWordResponse.java
+++ b/src/main/java/com/attica/athens/domain/chat/dto/response/BadWordResponse.java
@@ -1,6 +1,6 @@
 package com.attica.athens.domain.chat.dto.response;
 
-import com.attica.athens.domain.chat.component.FilterResult;
+import com.attica.athens.domain.chat.domain.FilterResult;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/attica/athens/domain/chat/dto/response/SendChatResponse.java
+++ b/src/main/java/com/attica/athens/domain/chat/dto/response/SendChatResponse.java
@@ -32,5 +32,3 @@ public record SendChatResponse(ChatType type, SendChatData data) {
         }
     }
 }
-
-

--- a/src/main/java/com/attica/athens/global/auth/jwt/Constants.java
+++ b/src/main/java/com/attica/athens/global/auth/jwt/Constants.java
@@ -10,7 +10,7 @@ public abstract class Constants {
 
     public static final String AUTHORITY_ROLE = "role";
 
-    public static final String COOKIE_NAME = "Refresh-Token";
+    public static final String COOKIE_NAME = "ATKN";
 
     public static final int COOKIE_EXPIRATION_TIME = 24 * 60 * 60;
 

--- a/src/test/java/com/attica/athens/domain/chat/domain/ChatAuthApiIntegrationTest.java
+++ b/src/test/java/com/attica/athens/domain/chat/domain/ChatAuthApiIntegrationTest.java
@@ -1,0 +1,85 @@
+package com.attica.athens.domain.chat.domain;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.attica.athens.domain.chat.component.BadWordFilter;
+import com.attica.athens.domain.chat.dto.request.SendChatRequest;
+import com.attica.athens.support.IntegrationTestSupport;
+import com.attica.athens.support.annotation.WithMockCustomUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.ResultActions;
+
+@DisplayName("채팅 인증 API 통합 테스트")
+public class ChatAuthApiIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private BadWordFilter badWordFilter;
+
+    @Nested
+    @DisplayName("채팅 비속어 필터 테스트")
+    class checkBadWord {
+
+        @Test
+        @DisplayName("채팅 내의 비속어 검사")
+        @Sql("/sql/enter-agora-members.sql")
+        @WithMockCustomUser
+        void 성공_비속어검사_비속어포함된채팅() throws Exception {
+            //given
+            badWordFilter.init();
+            SendChatRequest request = new SendChatRequest(ChatType.CHAT, "토론 병신같이 하네");
+
+            objectMapper = new ObjectMapper();
+            String jsonContent = objectMapper.writeValueAsString(request);
+
+            //when
+            final ResultActions result = mockMvc.perform(
+                    get("/{prefix}/agoras/{agoraId}/chats/filter", API_V1_AUTH, 1)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonContent)
+            );
+
+            result.andExpectAll(
+                    jsonPath("$.badword").isNotEmpty(),
+                    jsonPath("$.badword[0].start").value(3),
+                    jsonPath("$.badword[0].end").value(4),
+                    jsonPath("$.badword[0].keyword").value("병신")
+            );
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 아고라멤버로 채팅 검사를 한다")
+        @WithMockCustomUser("TeacherUnion")
+        void 실패_비속어필터_유효하지않은AgoraMember() throws Exception {
+            // given
+            SendChatRequest request = new SendChatRequest(ChatType.CHAT, "토론 병신같이 하네");
+
+            objectMapper = new ObjectMapper();
+            String jsonContent = objectMapper.writeValueAsString(request);
+
+            // when
+            final ResultActions result = mockMvc.perform(
+                    get("/{prefix}/agoras/{agoraId}/chats/filter", API_V1_AUTH, 1)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonContent)
+            );
+
+            // then
+            result.andExpect(status().isBadRequest())
+                    .andExpectAll(
+                            jsonPath("$.success").value(false),
+                            jsonPath("$.error").exists(),
+                            jsonPath("$.error.code").value(1102),
+                            jsonPath("$.error.message").value("User is not participating in the agora"),
+                            jsonPath("$.response").doesNotExist()
+                    );
+        }
+    }
+}

--- a/src/test/java/com/attica/athens/domain/chat/domain/ChatAuthApiIntegrationTest.java
+++ b/src/test/java/com/attica/athens/domain/chat/domain/ChatAuthApiIntegrationTest.java
@@ -55,6 +55,28 @@ public class ChatAuthApiIntegrationTest extends IntegrationTestSupport {
         }
 
         @Test
+        @DisplayName("채팅 내에 비속어가 없는 경우 200OK응답")
+        @Sql("/sql/enter-agora-members.sql")
+        @WithMockCustomUser
+        void 성공_비속어검사_비속어포함되지않은채팅() throws Exception {
+            //given
+            badWordFilter.init();
+            SendChatRequest request = new SendChatRequest(ChatType.CHAT, "토론 잘하시네요");
+
+            objectMapper = new ObjectMapper();
+            String jsonContent = objectMapper.writeValueAsString(request);
+
+            //when
+            final ResultActions result = mockMvc.perform(
+                    get("/{prefix}/agoras/{agoraId}/chats/filter", API_V1_AUTH, 1)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonContent)
+            );
+
+            result.andReturn().getResponse().getContentAsString().equals("비속어가 포함되어있지 않습니다.");
+        }
+
+        @Test
         @DisplayName("유효하지 않은 아고라멤버로 채팅 검사를 한다")
         @WithMockCustomUser("TeacherUnion")
         void 실패_비속어필터_유효하지않은AgoraMember() throws Exception {

--- a/src/test/java/com/attica/athens/domain/chat/domain/ChatOpenApiIntegrationTest.java
+++ b/src/test/java/com/attica/athens/domain/chat/domain/ChatOpenApiIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.attica.athens.domain.chat;
+package com.attica.athens.domain.chat.domain;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;


### PR DESCRIPTION
### 🔗 Linked Issue
- [ ] #167 

resolved: #167 

### 🛠 개발 기능
- 비속어 필터
- 채팅 내의 **비속어가 포함**되어있다면 `bad request` 응답과 함께 프론트에게 채팅 내의 `비속어 index`를 응답값으로 반환한다.
- 비속어가 포함되어있지 않다면 **정상 응답**한다.
- 기존의 **배열에 모든 비속어를 저장하여 비속어를 검사하는 방법은 성능이 매우 좋지 않다.**

### 🧩 해결 방법
- 따라서 `아호코라식 알고리즘`을 통하여 비속어를 `Trie` 자료구조로 **최초 등록**을 한 이후에
- `재활용` 하여 성능을 높혔다.

### 🔍 리뷰 포인트
- 처음 애플리케이션 실행할 때 Trie 자료구조에 비속어를 모두 등록하기 위해서 **비속어를 모두 가져와야** 하는데 
- 그러기 위해서 **데이터베이스에 따로 BadWord 엔티티를 만들어 저장**해두었습니다.
- 확인부탁드립니다.

## Reference
https://techblog.woowahan.com/15764/

<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
