### PR TITLE
kakao 로그인시 이메일 조회되도록 수정

### DIFF
--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -84,5 +84,5 @@ if [ -n "$CURRENT_COLOR" ]; then
   docker stop ${WAS_NAME}-${CURRENT_COLOR} || echo "Failed to stop container"
   docker rm -f ${WAS_NAME}-${CURRENT_COLOR} || echo "Failed to remove container"
 fi
-
+기
 echo "Deployment completed successfully."

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -84,5 +84,5 @@ if [ -n "$CURRENT_COLOR" ]; then
   docker stop ${WAS_NAME}-${CURRENT_COLOR} || echo "Failed to stop container"
   docker rm -f ${WAS_NAME}-${CURRENT_COLOR} || echo "Failed to remove container"
 fi
-기
+
 echo "Deployment completed successfully."

--- a/src/main/java/com/attica/athens/domain/member/domain/Member.java
+++ b/src/main/java/com/attica/athens/domain/member/domain/Member.java
@@ -7,14 +7,21 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.Map;
+import java.util.Map.Entry;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"email", "auth_provider"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseMember {
 
@@ -34,7 +41,7 @@ public class Member extends BaseMember {
     @Column(name = "oauth_id")
     private String oauthId;
 
-    @Column(length = 254, unique = true)
+    @Column(length = 254)
     @Size(max = 254)
     private String email;
 
@@ -93,6 +100,11 @@ public class Member extends BaseMember {
     }
 
     public void updateMemberInfo(OAuth2MemberInfo memberInfo) {
+        System.out.println("memberInfo");
+        Map<String, Object> attributes = memberInfo.getAttributes();
+        for (Entry<String, Object> entry : attributes.entrySet()) {
+            System.out.println(entry.getKey() + ":" + entry.getValue());
+        }
         this.email = memberInfo.getEmail().orElse(null);
     }
 }

--- a/src/main/java/com/attica/athens/domain/member/domain/Member.java
+++ b/src/main/java/com/attica/athens/domain/member/domain/Member.java
@@ -34,10 +34,6 @@ public class Member extends BaseMember {
     @Column(name = "oauth_id")
     private String oauthId;
 
-    @Column(length = 100)
-    @Size(max = 100)
-    private String nickname;
-
     @Column(length = 254, unique = true)
     @Size(max = 254)
     private String email;
@@ -46,7 +42,6 @@ public class Member extends BaseMember {
                    @NotNull String password,
                    @NotNull AuthProvider authProvider,
                    String oauthId,
-                   String nickname,
                    String email) {
         super(MemberRole.ROLE_USER);
 
@@ -58,7 +53,6 @@ public class Member extends BaseMember {
         this.password = password;
         this.authProvider = authProvider;
         this.oauthId = oauthId;
-        this.nickname = nickname;
         this.email = email;
     }
 
@@ -90,17 +84,15 @@ public class Member extends BaseMember {
      * @return
      */
     public static Member createMember(String username, String password, AuthProvider authProvider, String oauthId) {
-        return new Member(username, password, authProvider, oauthId, null, null);
+        return new Member(username, password, authProvider, oauthId, null);
     }
 
     public static Member createMemberWithOAuthInfo(OAuth2MemberInfo memberInfo, AuthProvider authProvider) {
         return new Member("DEFAULT", "NOPASSWORD", authProvider, memberInfo.getId(),
-                memberInfo.getNickname().orElse(null),
                 memberInfo.getEmail().orElse(null));
     }
 
     public void updateMemberInfo(OAuth2MemberInfo memberInfo) {
-        this.nickname = memberInfo.getNickname().orElse(null);
         this.email = memberInfo.getEmail().orElse(null);
     }
 }

--- a/src/main/java/com/attica/athens/domain/member/dto/response/GetMemberResponse.java
+++ b/src/main/java/com/attica/athens/domain/member/dto/response/GetMemberResponse.java
@@ -2,10 +2,10 @@ package com.attica.athens.domain.member.dto.response;
 
 import com.attica.athens.domain.member.domain.Member;
 
-public record GetMemberResponse(String authProvider, String nickname, String email) {
+public record GetMemberResponse(String authProvider, String email) {
 
-    public static GetMemberResponse from(Member member) {;
-        return new GetMemberResponse(member.getAuthProvider().name(), member.getNickname(),
+    public static GetMemberResponse from(Member member) {
+        return new GetMemberResponse(member.getAuthProvider().name(),
                 member.getEmail());
     }
 }

--- a/src/main/java/com/attica/athens/global/auth/config/oauth2/member/GoogleOAuth2MemberInfo.java
+++ b/src/main/java/com/attica/athens/global/auth/config/oauth2/member/GoogleOAuth2MemberInfo.java
@@ -17,11 +17,6 @@ public class GoogleOAuth2MemberInfo extends OAuth2MemberInfo {
     }
 
     @Override
-    public Optional<String> getNickname() {
-        return Optional.empty();
-    }
-
-    @Override
     public Optional<String> getEmail() {
         return Optional.ofNullable((String) attributes.get("email"));
     }

--- a/src/main/java/com/attica/athens/global/auth/config/oauth2/member/GoogleOAuth2MemberInfo.java
+++ b/src/main/java/com/attica/athens/global/auth/config/oauth2/member/GoogleOAuth2MemberInfo.java
@@ -7,17 +7,21 @@ import java.util.Optional;
  * 구글 OAuth2 사용자 정보
  */
 public class GoogleOAuth2MemberInfo extends OAuth2MemberInfo {
+
+    private static final String ID = "sub";
+    private static final String EMAIL = "email";
+
     public GoogleOAuth2MemberInfo(Map<String, Object> attributes) {
         super(attributes);
     }
 
     @Override
     public String getId() {
-        return (String) attributes.get("sub");
+        return (String) attributes.get(ID);
     }
 
     @Override
     public Optional<String> getEmail() {
-        return Optional.ofNullable((String) attributes.get("email"));
+        return Optional.ofNullable((String) attributes.get(EMAIL));
     }
 }

--- a/src/main/java/com/attica/athens/global/auth/config/oauth2/member/KakaoOAuth2MemberInfo.java
+++ b/src/main/java/com/attica/athens/global/auth/config/oauth2/member/KakaoOAuth2MemberInfo.java
@@ -17,15 +17,7 @@ public class KakaoOAuth2MemberInfo extends OAuth2MemberInfo {
     }
 
     @Override
-    public Optional<String> getNickname() {
-        return Optional.ofNullable(attributes.get("properties"))
-                .map(props -> (Map<String, Object>) props)
-                .map(props -> props.get("nickname"))
-                .map(Object::toString);
-    }
-
-    @Override
     public Optional<String> getEmail() {
-        return Optional.empty();
+        return Optional.ofNullable((String) attributes.get("email"));
     }
 }

--- a/src/main/java/com/attica/athens/global/auth/config/oauth2/member/KakaoOAuth2MemberInfo.java
+++ b/src/main/java/com/attica/athens/global/auth/config/oauth2/member/KakaoOAuth2MemberInfo.java
@@ -7,17 +7,26 @@ import java.util.Optional;
  * 카카오 OAuth2 사용자 정보
  */
 public class KakaoOAuth2MemberInfo extends OAuth2MemberInfo {
+
+    private static final String ID = "id";
+    private static final String KAKAO_ACCOUNT = "kakao_account";
+    private static final String EMAIL = "email";
+
     public KakaoOAuth2MemberInfo(Map<String, Object> attributes) {
         super(attributes);
     }
 
     @Override
     public String getId() {
-        return attributes.get("id").toString();
+        return attributes.get(ID).toString();
     }
 
     @Override
     public Optional<String> getEmail() {
-        return Optional.ofNullable((String) attributes.get("email"));
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get(KAKAO_ACCOUNT);
+        if (kakaoAccount == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable((String) kakaoAccount.get(EMAIL));
     }
 }

--- a/src/main/java/com/attica/athens/global/auth/config/oauth2/member/OAuth2MemberInfo.java
+++ b/src/main/java/com/attica/athens/global/auth/config/oauth2/member/OAuth2MemberInfo.java
@@ -22,7 +22,5 @@ public abstract class OAuth2MemberInfo {
 
     public abstract String getId();
 
-    public abstract Optional<String> getNickname();
-
     public abstract Optional<String> getEmail();
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -48,7 +48,7 @@ spring:
           authorizationGrantType: authorization_code
           redirectUri: ${KAKAO_REDIRECT_URI}
           scope:
-            - profile_nickname
+            - account_email
           clientName: Kakao
       # Provider 설정
       provider:

--- a/src/test/java/com/attica/athens/domain/member/MemberAuthApiIntegrationTest.java
+++ b/src/test/java/com/attica/athens/domain/member/MemberAuthApiIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.attica.athens.domain.member;
 
-import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -35,8 +34,7 @@ public class MemberAuthApiIntegrationTest extends IntegrationTestSupport {
                             jsonPath("$.success").value(true),
                             jsonPath("$.response").exists(),
                             jsonPath("$.response.authProvider").value("KAKAO"),
-                            jsonPath("$.response.nickname").exists(),
-                            jsonPath("$.response.email").value(nullValue()));
+                            jsonPath("$.response.email").exists());
         }
 
         @Test
@@ -55,7 +53,6 @@ public class MemberAuthApiIntegrationTest extends IntegrationTestSupport {
                             jsonPath("$.success").value(true),
                             jsonPath("$.response").exists(),
                             jsonPath("$.response.authProvider").value("GOOGLE"),
-                            jsonPath("$.response.nickname").value(nullValue()),
                             jsonPath("$.response.email").exists());
         }
     }

--- a/src/test/java/com/attica/athens/domain/member/MemberAuthApiIntegrationTest.java
+++ b/src/test/java/com/attica/athens/domain/member/MemberAuthApiIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.attica.athens.domain.member;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/com/attica/athens/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/attica/athens/domain/member/domain/MemberTest.java
@@ -113,7 +113,6 @@ class MemberTest {
             then(member.getPassword()).isEqualTo("NOPASSWORD");
             then(member.getAuthProvider()).isEqualTo(AuthProvider.KAKAO);
             then(member.getOauthId()).isEqualTo(oauthId);
-            then(member.getNickname()).isEqualTo(nickname);
         }
 
         @Test
@@ -148,20 +147,20 @@ class MemberTest {
         void 성공_멤버갱신_KakaoOauth정보() {
             // given
             String kakaoAccountId = "kakao123456789";
-            String initialNickname = "initialKakaoUser";
+            String initialEmail = "kakao@daum.net";
             KakaoOAuth2MemberInfo initialKakaoInfo = new KakaoOAuth2MemberInfo(Map.of(
                     "id", kakaoAccountId,
-                    "properties", Map.of(
-                            "nickname", initialNickname
+                    "kakao_account", Map.of(
+                            "email", initialEmail
                     ))
             );
             Member kakaoMember = createMemberWithOAuthInfo(initialKakaoInfo, AuthProvider.KAKAO);
 
-            String updatedNickname = "updatedKakaoUser";
+            String updatedEmail = "kakao2@daum.net";
             KakaoOAuth2MemberInfo updatedKakaoInfo = new KakaoOAuth2MemberInfo(Map.of(
                     "id", kakaoAccountId,
-                    "properties", Map.of(
-                            "nickname", updatedNickname
+                    "kakao_account", Map.of(
+                            "email", updatedEmail
                     ))
             );
 
@@ -169,7 +168,7 @@ class MemberTest {
             kakaoMember.updateMemberInfo(updatedKakaoInfo);
 
             // then
-            then(kakaoMember.getNickname()).isEqualTo(updatedNickname);
+            then(kakaoMember.getEmail()).isEqualTo(updatedEmail);
         }
 
         @Test

--- a/src/test/java/com/attica/athens/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/attica/athens/domain/member/domain/MemberTest.java
@@ -147,7 +147,7 @@ class MemberTest {
         void 성공_멤버갱신_KakaoOauth정보() {
             // given
             String kakaoAccountId = "kakao123456789";
-            String initialEmail = "kakao@daum.net";
+            String initialEmail = "kakao@hanmail.net";
             KakaoOAuth2MemberInfo initialKakaoInfo = new KakaoOAuth2MemberInfo(Map.of(
                     "id", kakaoAccountId,
                     "kakao_account", Map.of(
@@ -156,7 +156,7 @@ class MemberTest {
             );
             Member kakaoMember = createMemberWithOAuthInfo(initialKakaoInfo, AuthProvider.KAKAO);
 
-            String updatedEmail = "kakao2@daum.net";
+            String updatedEmail = "kakao2@hanmail.net";
             KakaoOAuth2MemberInfo updatedKakaoInfo = new KakaoOAuth2MemberInfo(Map.of(
                     "id", kakaoAccountId,
                     "kakao_account", Map.of(


### PR DESCRIPTION
### 🛠 개발 기능
- 카카오 로그인한 사용자 정보 조회시 이메일 정보가 제공되도록 수정한다.
  - 비즈 앱 설정 수행 
- 구글과 카카오 Oauth 정보를 이메일 정보 관리로 통합한다.


<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
