### PR TITLE
[#261]refactor: 비속어 필터 로직 수정

### DIFF
--- a/src/main/java/com/attica/athens/domain/chat/component/BadWordFilter.java
+++ b/src/main/java/com/attica/athens/domain/chat/component/BadWordFilter.java
@@ -3,6 +3,7 @@ package com.attica.athens.domain.chat.component;
 import com.attica.athens.domain.chat.dao.BadWordRepository;
 import com.attica.athens.domain.chat.domain.BadWord;
 import com.attica.athens.domain.chat.domain.FilterResult;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -33,7 +34,40 @@ public class BadWordFilter {
     }
 
     public FilterResult filter(String text) {
-        Collection<Emit> emits = trie.parseText(text);
-        return new FilterResult(text, emits);
+        Collection<Emit> allEmits = trie.parseText(text);
+        Collection<Emit> filteredEmits = removeShorterOverlappingMatches(allEmits);
+        return new FilterResult(text, filteredEmits);
+    }
+
+    private Collection<Emit> removeShorterOverlappingMatches(Collection<Emit> emits) {
+        List<Emit> emitList = new ArrayList<>(emits);
+        List<Emit> result = new ArrayList<>();
+
+        emitList.sort((e1, e2) -> Integer.compare(e1.getStart(), e2.getStart()));
+
+        for (int i = 0; i < emitList.size(); i++) {
+            Emit current = emitList.get(i);
+            boolean isContained = false;
+
+            for (int j = 0; j < emitList.size(); j++) {
+                if (i == j) {
+                    continue;
+                }
+
+                Emit other = emitList.get(j);
+
+                if (current.getStart() >= other.getStart() && current.getEnd() <= other.getEnd()
+                        && current.getKeyword().length() < other.getKeyword().length()) {
+                    isContained = true;
+                    break;
+                }
+            }
+
+            if (!isContained) {
+                result.add(current);
+            }
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
### 🔗 Linked Issue
- [ ] #261 

### 🛠 문제
- Aho-Corasick 알고리즘의 특성 때문에 텍스트에서 모든 패턴을 찾기 때문에 `시발놈`을 입력했을 때 `시발`과 `시발놈` 두 개의 패턴이 모두 발견된다.

### 🧩 해결 방법
- 중첩된 매칭 중에서 가장 긴 매칭만 유지하도록 코드를 수정한다.

<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
